### PR TITLE
People identified by name and e-mail when handling content

### DIFF
--- a/pycvsanaly2/DBContentHandler.py
+++ b/pycvsanaly2/DBContentHandler.py
@@ -193,8 +193,8 @@ class DBContentHandler (ContentHandler):
 
             name = to_utf8 (person.name)
             email = person.email
-            cursor.execute (statement ("SELECT id from people where name = ?",
-                            self.db.place_holder), (name,))
+            cursor.execute (statement ("SELECT id from people where name = ? and email = ?",
+                            self.db.place_holder), (name, email))
             rs = cursor.fetchone ()
             if not rs:
                 p = DBPerson (None, person)
@@ -209,13 +209,13 @@ class DBContentHandler (ContentHandler):
 
             return person_id
 
-        name = to_utf8 (person.name)
+        name, email = to_utf8 (person.name), person.email
 
-        if name in self.people_cache:
-            person_id = self.people_cache[name]
+        if (name, email) in self.people_cache:
+            person_id = self.people_cache[name, email]
         else:
             person_id = ensure_person (person)
-            self.people_cache[name] = person_id
+            self.people_cache[name, email] = person_id
 
         return person_id
 


### PR DESCRIPTION
While working with Tom Mens (UMONS Software Engineering Lab) on GNOME repository analysis, and using CVSAnaly to extract git repositories, I realized that when parsing many repositories in the same database CVSAnaly matches people table entries using only the person's name. As consequence, if a person uses many e-mail addresses only one e-mail address is kept in the database. To solve the problem I wrote a small patch modifying how people are retrieved from the table during repository parsing. I hope you can accept this patch. Do not hesitate to contact me or Tom Mens if you need further information.
