### PR TITLE
Add a notice about "max_allowed_packet" to README

### DIFF
--- a/README
+++ b/README
@@ -92,6 +92,10 @@ version of your repository, and then run cvsanaly2:
 More options, and a more detailed info about the options, can be
 learnt by running "cvsanaly2 --help"
 
+Useful settings
+-------
+* Raise your `max_allowed_packet`-setting of your database (MySQL). 1 or 16 MB might be to low (depends on your repository)
+
  Analysis
 ---------
 


### PR DESCRIPTION
Some people ran into problems / errors about max_allowed_packet-setting of MySQL (e.g. #11).
It might be useful to raise this setting to a higher value (e.g. 64MB)

This pull request is about a short notice to solve this problem.
At the moment there is no documentation for this tool. So the README file might be a good place.
