### PR TITLE
[IMPROVEMENT] Ignore production config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.pyc
 MANIFEST
 dist/
+config


### PR DESCRIPTION
CVSAnalY provides a config.sample file and the possibility to add a config file argument to run the program.

If you copy config.sample to config in the same directory, the git repository is always "unclean".

Solution: Ignore the config while which is used for production.
