### PR TITLE
Wrong pattern in GitLineCounter

### DIFF
--- a/pycvsanaly2/extensions/CommitsLOC.py
+++ b/pycvsanaly2/extensions/CommitsLOC.py
@@ -142,7 +142,7 @@ class SVNLineCounter (LineCounter):
 
 class GitLineCounter (LineCounter):
 
-    diffstat_pattern = re.compile ("^ \d+ files changed(, (\d+) insertions\(\+\))?(, (\d+) deletions\(\-\))?$")
+    diffstat_pattern = re.compile ("^ \d+ files? changed(, (\d+) insertions?\(\+\))?(, (\d+) deletions?\(\-\))?$")
 
     def __init__ (self, repo, uri):
         LineCounter.__init__ (self, repo, uri)


### PR DESCRIPTION
The pattern should match a case when the change is in 1 file, or the change introduces 1 insertion or 1 deletion (in that case git prints word in singular form not plural)
