### PR TITLE
[FEATURE] Add option to list all available extensions

### DIFF
--- a/pycvsanaly2/ExtensionsManager.py
+++ b/pycvsanaly2/ExtensionsManager.py
@@ -19,6 +19,7 @@
 
 from extensions import get_extension, ExtensionRunError, ExtensionUnknownError
 from utils import printerr, printout
+import os
 
 class ExtensionException (Exception):
     '''ExtensionException'''
@@ -83,4 +84,17 @@ class ExtensionsManager:
                 continue
                     
             self.run_extension (name, extension, repo, uri, db)
-    
+
+    def load_all_extensions (self):
+        extensions = {}
+        dir = os.path.dirname(os.path.realpath(__file__))
+        for files in os.listdir(dir + "/extensions"):
+            if files.endswith(".py"):
+                ext = files[:-3]
+                try:
+                    extensions[ext] = get_extension(ext)
+                except ExtensionUnknownError:
+                    # Do nothing here, because we ignore errors during showing "help" ;)
+                    pass
+
+        return extensions.keys()

--- a/pycvsanaly2/extensions/__init__.py
+++ b/pycvsanaly2/extensions/__init__.py
@@ -43,5 +43,10 @@ def get_extension (extension_name):
         except ImportError as e:
             raise ExtensionUnknownError (e.message)
 
+    # If the file can be loaded, but no register_extension() is called
+    # this is not a valid extension. Raise an ExtensionUnknownError
+    if extension_name not in _extensions:
+        raise ExtensionUnknownError("Extension %s unknown" % extension_name)
+
     return _extensions[extension_name]
 

--- a/pycvsanaly2/main.py
+++ b/pycvsanaly2/main.py
@@ -64,7 +64,6 @@ Options:
   -l, --repo-logfile=path        Logfile to use instead of getting log from the repository
   -s, --save-logfile[=path]      Save the repository log to the given path
   -n, --no-parse                 Skip the parsing process. It only makes sense in conjunction with --extensions
-      --extensions=ext1,ext2,    List of extensions to run        
 
 Database:
 
@@ -78,16 +77,22 @@ Metrics Options:
 
       --metrics-all              Get metrics for every revision, not only for HEAD
       --metrics-noerr            Ignore errors when calculating metrics
+
+Extensions:
+
+  -e, --list-extensions          Show all available extensions
+      --extensions=ext1,ext2     List of extensions to run
+
 """
 
 def main (argv):
     # Short (one letter) options. Those requiring argument followed by :
-    short_opts = "hVgqnf:l:s:u:p:d:H:"
+    short_opts = "hVgqnf:l:s:u:p:d:H:e"
     # Long options (all started by --). Those requiring argument followed by =
     long_opts = ["help", "version", "debug", "quiet", "profile", "config-file=", 
                  "repo-logfile=", "save-logfile=", "no-parse", "db-user=", "db-password=",
                  "db-hostname=", "db-database=", "db-driver=", "extensions=",
-                 "metrics-all", "metrics-noerr"]
+                 "metrics-all", "metrics-noerr", "list-extensions"]
 
     # Default options
     debug = None
@@ -115,6 +120,11 @@ def main (argv):
     for opt, value in opts:
         if opt in ("-h", "--help", "-help"):
             usage ()
+            return 0
+        elif opt in ("-e", "--list-extensions"):
+            emg = ExtensionsManager ([])
+            allExtensions = emg.load_all_extensions()
+            print ", ".join(sorted(allExtensions))
             return 0
         elif opt in ("-V", "--version"):
             print VERSION


### PR DESCRIPTION
At the moment, there is no option to list all available extensions.
The extensions are located in `pycvsanaly2/extensions`, but not every file is ready to use or throws some errors.

To identify which extension is usable and ready to activate i`ve introduced to new command line options:
- `cvsanaly2 --list-extensions`
- `cvsanaly2 -e` 

Both options do the same: List all available extensions.

With the current master, the code with output:

``` bash
andygrunwald ~/Development/cvsanaly2 (master) $ cvsanaly2 --list-extensions
CommitsLOC, FileTypes, MessageWordsPrint, Metrics, Patches
```

PS: I`m very new to python. If there are some "python uncommon source / paradigm", please let me know. I will correct it.
