### PR TITLE
[BUGFIX] #9 - Error message wrongly raised: "Invalid extension Weeks"

### DIFF
--- a/pycvsanaly2/ExtensionsManager.py
+++ b/pycvsanaly2/ExtensionsManager.py
@@ -24,8 +24,9 @@ class ExtensionException (Exception):
     '''ExtensionException'''
 
 class InvalidExtension (ExtensionException):
-    def __init__ (self, name):
+    def __init__ (self, name, message):
         self.name = name
+        self.message = message
 
 class InvalidDependency (ExtensionException):
     def __init__ (self, name1, name2):
@@ -39,8 +40,8 @@ class ExtensionsManager:
         for ext in exts:
             try:
                 self.exts[ext] = get_extension (ext)
-            except ExtensionUnknownError:
-                raise InvalidExtension (ext)
+            except ExtensionUnknownError as e:
+                raise InvalidExtension (ext, e.message)
 
             # Add dependencies
             for dep in self.exts[ext].deps:

--- a/pycvsanaly2/extensions/__init__.py
+++ b/pycvsanaly2/extensions/__init__.py
@@ -40,11 +40,8 @@ def get_extension (extension_name):
     if extension_name not in _extensions:
         try:
             __import__ ("pycvsanaly2.extensions.%s" % extension_name)
-        except ImportError:
-            pass
-
-    if extension_name not in _extensions:
-        raise ExtensionUnknownError ('Extension %s not registered' % extension_name)
+        except ImportError as e:
+            raise ExtensionUnknownError (e.message)
 
     return _extensions[extension_name]
 

--- a/pycvsanaly2/main.py
+++ b/pycvsanaly2/main.py
@@ -246,7 +246,7 @@ def main (argv):
     try:
         emg = ExtensionsManager (config.extensions)
     except InvalidExtension, e:
-        printerr ("Invalid extension %s", (e.name,))
+        printerr ("Invalid extension %s (%s)", (e.name, e.message,))
         return 1
     except InvalidDependency, e:
         printerr ("Extension %s depends on extension %s which is not a valid extension", (e.name1, e.name2))


### PR DESCRIPTION
During some "playing around with CVSAnalY" i ran into the bug which was reported by @dicortazar in #9 Error message wrongly raised: "Invalid extension Weeks".

Here is my proposal to solve this issue:

The error is reproducable, if you does not have `pysqlite2.dbapi2` installed.

With the current master, you got the error `Invalid extension Weeks`.
With this patch you will get `Invalid extension Weeks (No module named pysqlite2.dbapi2)`

Maybe this is not the best solution to this problem, but this are more information as the current error message.
