### PR TITLE
Resolve extension dependencies recursivly

### DIFF
--- a/pycvsanaly2/ExtensionsManager.py
+++ b/pycvsanaly2/ExtensionsManager.py
@@ -43,12 +43,17 @@ class ExtensionsManager:
                 raise InvalidExtension (ext)
 
             # Add dependencies
-            for dep in self.exts[ext].deps:
-                if dep not in self.exts.keys ():
-                    try:
-                        self.exts[dep] = get_extension (dep)
-                    except:
-                        raise InvalidDependency (ext, dep)
+            self.determine_deps (ext)
+
+    def determine_deps (self, ext):
+        for dep in self.exts[ext].deps:
+            if dep not in self.exts.keys ():
+                try:
+                    self.exts[dep] = get_extension (dep)
+                    if self.exts[dep].deps:
+                        self.determine_deps (dep)
+                except:
+                    raise InvalidDependency (ext, dep)
 
     def run_extension (self, name, extension, repo, uri, db):
         printout ("Executing extension %s", (name,))


### PR DESCRIPTION
The extension `MetricsEvo` depends on extension `Metrics`.
But this dependency is not added to the extension as `deps`.
This is mentioned in a comment in `MetricsEvo.py` only.

On the other hand the extension `Metrics` depends on extension `FileTypes`.
This dependency is marked as `dep` in `Metrics.py`.

At the moment it is not possible to add `Metrics` add extension dependency, because the extension dependencies are not resolved recursivly.

With this pull request it is possible to add `Metrics` as dependency by `MetricsEvo`
