### PR TITLE
Make extension MessageWords working again

### DIFF
--- a/pycvsanaly2/extensions/MessageWords.py
+++ b/pycvsanaly2/extensions/MessageWords.py
@@ -42,7 +42,7 @@ class TableWords (DBTable):
     _sql_create_table_mysql = "CREATE TABLE words_freq (" + \
         "id INTEGER PRIMARY KEY," + \
         "date DATETIME," + \
-        "word VARCHAR(80)," + \
+        "word VARCHAR(150)," + \
         "times INTEGER" + \
         ") CHARACTER SET=utf8"
 
@@ -122,7 +122,7 @@ class MessageWords (Extension):
                 theTableWords.add_pending_row ((None, date,
                                                 word, wordsFreq[word]))
             theTableWords.insert_rows (write_cursor)
-        #cnn.commit ()
+        cnn.commit ()
         write_cursor.close ()
         cursor.close ()
         cnn.close ()


### PR DESCRIPTION
If you add `MessageWords` to your extension configuration, the table will be empty after analysis.

This commit makes this extension working again.
For a test i`ve analyzed this repository. During this progress ive detected that the longest word is longer than 80 chars. It is 96 (it is a URL).

Due to this ive extended the sql column `word` to 150 chars. This might be enough for the future.
