### PR TITLE
Added commit graph

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
-/.project
-/.pydevproject
 *~
 *.pyc
 .idea

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+/.project
+/.pydevproject
 *~
 *.pyc
 .idea

--- a/pycvsanaly2/GitParser.py
+++ b/pycvsanaly2/GitParser.py
@@ -115,6 +115,7 @@ class GitParser(Parser):
             parents = match.group(3)
             if parents:
                 parents = parents.split()
+                self.commit.parents = parents
             git_commit = self.GitCommit(self.commit, parents)
 
             decorate = match.group(5)

--- a/pycvsanaly2/Repository.py
+++ b/pycvsanaly2/Repository.py
@@ -27,7 +27,8 @@ class Commit:
                          'branch': None,
                          'tags': None,
                          'message': "",
-                         'composed_rev': False}
+                         'composed_rev': False,
+                         'parents': []}
 
     def __getinitargs__(self):
         return ()


### PR DESCRIPTION
Hi CVSAnalY team,

I decided to put my new changes to CVSAnalY instead of MininGit. This is my first batch of changes. It adds a commit graph to keep track of parents of commits. This commit graph currently only supports Git, as it is not necessary in Subversion and CVS. Hope someone could implement a Bzr version if it is necessary (I am not familiar with Bzr).

With regards to #1, I will pick features that I am actively using from MininGit and merge them into CVSAnalY incrementally, instead of merging all changes at once.
