### PR TITLE
Change import of pysqlite2.dbapi2 to sqlite3 in file_test_path.py

### DIFF
--- a/tests/file_path_test.py
+++ b/tests/file_path_test.py
@@ -28,7 +28,7 @@ import unittest
 import os
 import shutil
 import tempfile
-import pysqlite2.dbapi2 as db
+import sqlite3 as db
 import pycvsanaly2.main
 
 class FilePathTestCase(unittest.TestCase):


### PR DESCRIPTION
In 8bf90117af6927041b646ba5e84fa4b59cb87bf1 and #48 all imports of `pysqlite2.dbapi2` were replaced by `sqlite3`.

The file file_test_path.py was forgotten.
Here we changed the import as well.
