### PR TITLE
File tests/file_path_test.py loads wrong TestCase

### DIFF
--- a/tests/file_path_test.py
+++ b/tests/file_path_test.py
@@ -65,5 +65,5 @@ class FilePathTestCase(unittest.TestCase):
         self.assertItemsEqual (actual, expected)
 
 if __name__ == "__main__":
-    suite = unittest.TestLoader().loadTestsFromTestCase(UnicodeTestCase)
+    suite = unittest.TestLoader().loadTestsFromTestCase(FilePathTestCase)
     unittest.TextTestRunner(verbosity=2).run(suite)


### PR DESCRIPTION
The TestCase `FilePathTestCase` located in `tests/file_path_test.py` loads the TestCase `UnicodeTestCase` instead of `FilePathTestCase`.
