### PR TITLE
Make tests/file_path_test.py pass again

### DIFF
--- a/tests/file_path_test.py
+++ b/tests/file_path_test.py
@@ -60,7 +60,7 @@ class FilePathTestCase(unittest.TestCase):
         connection.close()
         os.remove(temp_file_name)
 
-        expected = [(u'aaa',), (u'aaa/otherthing',), (u'aaa/something',), (u'bbb',), (u'bbb/bthing',), (u'bbb/something',), (u'bbb/ccc',), (u'bbb/ccc/yet_anotherthing',), (u'ddd',), (u'ddd/finalthing',), (u'eee',), (u'eee/fff',), (u'eee/fff/wildthing',)]
+        expected = [(u'aaa',), (u'aaa/otherthing',), (u'aaa/something',), (u'bbb',), (u'bbb/bthing',), (u'bbb/something',), (u'bbb/ccc',), (u'bbb/ccc/yet_anotherthing',), (u'bbb/something.renamed',), (u'ddd',), (u'ddd/finalthing',), (u'eee',), (u'eee/fff',), (u'eee/fff/wildthing',)]
 
         self.assertItemsEqual (actual, expected)
 


### PR DESCRIPTION
Currently, the unittest `tests/file_path_test.py` did not pass.
The reason is a missing entry in the expected result.

This PR make the test pass again :)
