### PR TITLE
Add support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+language: python
+
+python:
+  - "2.6"
+  - "2.7"
+  - "pypy"
+
+install:
+  # Install "discover" to support discover command in unittest
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install unittest2; fi
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then pip install discover; fi
+  # Install RepositoryHandler
+  - git clone https://github.com/MetricsGrimoire/RepositoryHandler.git
+  - cd RepositoryHandler
+  - python setup.py install
+  # Install CVSAnaly
+  - cd ..
+  - python setup.py install
+
+# Run tests
+script:
+  - if [[ $TRAVIS_PYTHON_VERSION == '2.6' ]]; then unit2 discover . '*_test.py'; fi
+  - if [[ $TRAVIS_PYTHON_VERSION > '2.6' ]]; then python -m unittest discover . '*_test.py'; fi
+
+notifications:
+  irc: "chat.freenode.net#metrics-grimoire"

--- a/tests/file_path_test.py
+++ b/tests/file_path_test.py
@@ -24,12 +24,20 @@
 # To execute this test, run: "python -m unittest tests.file_path_test" in the
 # root of the project
 
-import unittest
+import sys
 import os
 import shutil
 import tempfile
 import sqlite3 as db
 import pycvsanaly2.main
+
+requiredVersion = (2,7)
+currentVersion = sys.version_info
+
+if currentVersion >= requiredVersion:
+    import unittest
+else:
+    import unittest2 as unittest
 
 class FilePathTestCase(unittest.TestCase):
 

--- a/tests/unicode_test.py
+++ b/tests/unicode_test.py
@@ -23,8 +23,16 @@
 # To execute this test, run: "python -m unittest tests.unicode_test" in the root
 # of the project
 
-import unittest
+import sys
 from pycvsanaly2 import utils
+
+requiredVersion = (2,7)
+currentVersion = sys.version_info
+
+if currentVersion >= requiredVersion:
+    import unittest
+else:
+    import unittest2 as unittest
 
 class UnicodeTestCase(unittest.TestCase):
 


### PR DESCRIPTION
Travis CI (http://travis-ci.org) is a hosted, distributed continuous integration service used to build and test projects hosted at GitHub.

It supports various languages and is free to use.
It offers PR support. This means, every PR is tested against the CI script which is supported by the file .travis.yml in the repository.

A complete documentation can be found here: http://docs.travis-ci.com/

How the complete setup can be look like, here is a complete integration: https://travis-ci.org/andygrunwald/CVSAnalY

The configuration is very easy and can be found in the PR and here: https://github.com/andygrunwald/CVSAnalY/blob/develop-travisci/.travis.yml

The IRC notification after every build looks like:

```
<travis-ci> [travis-ci] andygrunwald/CVSAnalY#16 (develop-travisci - 15157a6 : Andy Grunwald): The build passed.
<travis-ci> [travis-ci] Change view : https://github.com/andygrunwald/CVSAnalY/compare/d8400400ef41...15157a63a3f6
<travis-ci> [travis-ci] Build details : http://travis-ci.org/andygrunwald/CVSAnalY/builds/18637758
```

After merge of this PR you have to setup and test the Github service hook under https://github.com/MetricsGrimoire/CVSAnalY/settings/hooks.
I do not have the rights to do this. But i can support you.
