### PR TITLE
Travisci readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # CVSAnaly
 
+[![Build Status](https://travis-ci.org/MetricsGrimoire/CVSAnalY.svg?branch=master)](https://travis-ci.org/MetricsGrimoire/CVSAnalY)
+
 ## Description
 
 The CVSAnalY tool extracts information out of source code repository logs and stores it into a database.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,4 @@
-# CVSAnaly
-
-[![Build Status](https://travis-ci.org/MetricsGrimoire/CVSAnalY.svg?branch=master)](https://travis-ci.org/MetricsGrimoire/CVSAnalY)
+# CVSAnaly [![Build Status](https://travis-ci.org/MetricsGrimoire/CVSAnalY.svg?branch=master)](https://travis-ci.org/MetricsGrimoire/CVSAnalY)
 
 ## Description
 


### PR DESCRIPTION
TravisCI got a build status. Is the build failing? Was the last build a success?
It is easy to integrate this in the local readme for other visitors.

An example how it looks like can be found here: https://github.com/andygrunwald/CVSAnalY/tree/travisci-readme
