### PR TITLE
Make path for cache file configurable

### DIFF
--- a/config.sample
+++ b/config.sample
@@ -11,6 +11,9 @@
 # save_logfile = None
 # no_parse = False
 #
+# Writable path for CVSAnaly (used for caching, maybe config, etc.)
+# writable_path = None
+#
 ## Database parameters
 # db_driver = 'mysql'
 # db_user = 'operator'

--- a/pycvsanaly2/Config.py
+++ b/pycvsanaly2/Config.py
@@ -30,6 +30,7 @@ class Config:
                       'profile': False,
                       'repo_logfile': None,
                       'save_logfile': None,
+                      'writable_path': None,
                       'no_parse': False,
                       'files' : [],
                       'db_driver': 'mysql',
@@ -80,6 +81,10 @@ class Config:
             pass
         try:
             self.save_logfile = config.save_logfile
+        except:
+            pass
+        try:
+            self.writable_path = config.writable_path
         except:
             pass
         try:

--- a/pycvsanaly2/main.py
+++ b/pycvsanaly2/main.py
@@ -64,6 +64,7 @@ Options:
   -f, --config-file              Use a custom configuration file
   -l, --repo-logfile=path        Logfile to use instead of getting log from the repository
   -s, --save-logfile[=path]      Save the repository log to the given path
+  -w, --writable-path[=path]     Storage of files (e.g. cache, config) to the given path
   -n, --no-parse                 Skip the parsing process. It only makes sense in conjunction with --extensions
       --files=file1,file2        Only analyze the history of these files or directories. Ignored when '-l' flag is set.
       --git-ref                  Parse only commit tree starting with this reference. (Git only)
@@ -91,12 +92,12 @@ Extensions:
 
 def main(argv):
     # Short (one letter) options. Those requiring argument followed by :
-    short_opts = "hVgqnf:l:s:u:p:d:H:e"
+    short_opts = "hVgqnf:l:s:u:p:d:H:w:e"
     # Long options (all started by --). Those requiring argument followed by =
     long_opts = ["help", "version", "debug", "quiet", "profile", "config-file=",
                  "repo-logfile=", "save-logfile=", "no-parse", "files=",
                  "db-user=", "db-password=", "db-hostname=", "db-database=", "db-driver=",
-                 "extensions=", "metrics-all", "metrics-noerr", "list-extensions", "git-ref="]
+                 "extensions=", "metrics-all", "metrics-noerr", "list-extensions", "git-ref=", "writable-path="]
 
     # Default options
     debug = None
@@ -112,6 +113,7 @@ def main(argv):
     driver = None
     logfile = None
     save_logfile = None
+    writable_path = None
     extensions = None
     metrics_all = None
     metrics_noerr = None
@@ -161,6 +163,8 @@ def main(argv):
             logfile = value
         elif opt in ("-s", "--save-logfile"):
             save_logfile = value
+        elif opt in ("-w", "--writable-path"):
+            writable_path = value
         elif opt in ("--extensions", ):
             extensions = value.split(',')
         elif opt in ("--metrics-all", ):
@@ -195,6 +199,8 @@ def main(argv):
         config.repo_logfile = logfile
     if save_logfile is not None:
         config.save_logfile = save_logfile
+    if writable_path is not None:
+        config.writable_path = writable_path
     if no_parse is not None:
         config.no_parse = no_parse
     if files is not None:
@@ -225,6 +231,11 @@ def main(argv):
         import repositoryhandler.backends
 
         repositoryhandler.backends.DEBUG = True
+
+    if config.writable_path is not None:
+        from utils import set_writable_path_from_config
+        set_writable_path_from_config('cache', config.writable_path)
+        set_writable_path_from_config('dot', config.writable_path)
 
     # Create repository
     path = uri_to_filename(uri)

--- a/pycvsanaly2/utils.py
+++ b/pycvsanaly2/utils.py
@@ -146,14 +146,7 @@ def cvsanaly_dot_dir():
         pass
 
     dot_dir = os.path.join(os.environ.get('HOME'), '.cvsanaly2')
-    try:
-        os.mkdir(dot_dir, 0700)
-    except OSError, e:
-        if e.errno == errno.EEXIST:
-            if not os.path.isdir(dot_dir):
-                raise
-        else:
-            raise
+    create_directory(dot_dir)
 
     _dirs['dot'] = dot_dir
 
@@ -167,18 +160,35 @@ def cvsanaly_cache_dir():
         pass
 
     cache_dir = os.path.join(cvsanaly_dot_dir(), 'cache')
-    try:
-        os.mkdir(cache_dir, 0700)
-    except OSError, e:
-        if e.errno == errno.EEXIST:
-            if not os.path.isdir(cache_dir):
-                raise
-        else:
-            raise
+    create_directory(cache_dir)
 
     _dirs['cache'] = cache_dir
 
     return cache_dir
+
+
+def create_directory(path):
+    try:
+        os.makedirs(path, 0700)
+    except OSError, e:
+        if e.errno == errno.EEXIST:
+            if not os.path.isdir(path):
+                raise
+        else:
+            raise
+
+
+def set_writable_path_from_config(context, path):
+    if context == 'cache':
+        path_postfix = os.path.join('.cvsanaly2', context)
+    elif context == 'dot':
+        path_postfix = '.cvsanaly2'
+    else:
+        raise TypeError("foo")
+
+    directory = os.path.join(path, path_postfix)
+    create_directory(directory)
+    _dirs[context] = directory
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
CVSAnaly relies on a directory in the home dir of the (system) user who executes cvsanaly.
This directory is used for cache file and config file if no other one is specified.
The path is built in [utils.py](https://github.com/MetricsGrimoire/CVSAnalY/blob/master/pycvsanaly2/utils.py#L148).

To get the path of a user is kind of problematic in python (os.environ.get('HOME')).
For example if you executes the process in a sub process (e.g. via [supervisor](http://supervisord.org/)), the wrong user is determined.

Situation:
- Supervisor runs as root
- Supervisor is configured to run the subprocess as user x
- Python script gets os.environ.get('HOME') => /root

Further more the user should chose the location of the cache file.
This pull request makes the file location configurable.
