### PR TITLE
Metrics-Extension: Fixed AttributeError: 'NoneType' object has no

### DIFF
--- a/pycvsanaly2/extensions/Metrics.py
+++ b/pycvsanaly2/extensions/Metrics.py
@@ -590,6 +590,11 @@ class MetricsJob(Job):
         def write_file(line, fd):
             fd.write(line)
 
+        #skip this if self.path is None, this can happen in new versions
+        if self.path is None:
+            printerr("No path for file %d in commit '%s'", (self.file_id, self.rev))
+            return
+        
         self.measures = Measures()
 
         repo_type = repo.get_type()


### PR DESCRIPTION
attribute 'strip'

This is similar to commit 34525e927ffb31795b45145dcddf29fa20675d96. In
new versions path can be None, so I added an if block to check if that
is the case, and return if so.
